### PR TITLE
Inject ViewModel and its dependencies

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -86,6 +86,7 @@ dependencies {
     kapt(libs.hilt.compiler)
 
     testImplementation(libs.junit)
+    testImplementation(libs.mockk)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.espresso)
     androidTestImplementation(libs.ui.test.junit4)

--- a/app/src/main/java/jp/speakbuddy/edisonandroidexercise/MainActivity.kt
+++ b/app/src/main/java/jp/speakbuddy/edisonandroidexercise/MainActivity.kt
@@ -3,15 +3,19 @@ package jp.speakbuddy.edisonandroidexercise
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.activity.viewModels
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.ui.Modifier
+import dagger.hilt.android.AndroidEntryPoint
 import jp.speakbuddy.edisonandroidexercise.ui.fact.FactScreen
 import jp.speakbuddy.edisonandroidexercise.ui.fact.FactViewModel
 import jp.speakbuddy.edisonandroidexercise.ui.theme.EdisonAndroidExerciseTheme
 
+@AndroidEntryPoint
 class MainActivity : ComponentActivity() {
+    private val factViewModel: FactViewModel by viewModels()
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContent {
@@ -21,7 +25,7 @@ class MainActivity : ComponentActivity() {
                     modifier = Modifier.fillMaxSize(),
                     color = MaterialTheme.colorScheme.background
                 ) {
-                    FactScreen(viewModel = FactViewModel())
+                    FactScreen(viewModel = factViewModel)
                 }
             }
         }

--- a/app/src/main/java/jp/speakbuddy/edisonandroidexercise/dev_plan.md
+++ b/app/src/main/java/jp/speakbuddy/edisonandroidexercise/dev_plan.md
@@ -31,12 +31,12 @@
 # Implementation Plan
 - Update to TOML :white_check_mark:
 - Update latest dependencies :white_check_mark:
-- Implement Hilt
-    - Add NetworkModule
-    - Update Application
-    - Update Service Provider (use Hilt)
-    - Update FactViewModel to use serviceProvider and enable DI
-    - Inject ViewModel on Activity
+- Implement Hilt :white_check_mark:
+    - Add NetworkModule :white_check_mark:
+    - Update Application :white_check_mark:
+    - Update Service Provider (use Hilt) :white_check_mark:
+    - Update FactViewModel to use serviceProvider and enable DI :white_check_mark:
+    - Inject ViewModel on Activity :white_check_mark:
 - Consider moving FactResponse to separate class
 - Add FactEntity
 - Add FactLocalDataSource

--- a/app/src/main/java/jp/speakbuddy/edisonandroidexercise/network/FactService.kt
+++ b/app/src/main/java/jp/speakbuddy/edisonandroidexercise/network/FactService.kt
@@ -1,10 +1,6 @@
 package jp.speakbuddy.edisonandroidexercise.network
 
-import com.jakewharton.retrofit2.converter.kotlinx.serialization.asConverterFactory
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.json.Json
-import okhttp3.MediaType.Companion.toMediaType
-import retrofit2.Retrofit
 import retrofit2.http.GET
 
 interface FactService {
@@ -17,12 +13,3 @@ data class FactResponse(
     val fact: String,
     val length: Int
 )
-
-object FactServiceProvider {
-    fun provide(): FactService =
-        Retrofit.Builder()
-            .baseUrl("https://catfact.ninja/")
-            .addConverterFactory(Json.asConverterFactory("application/json".toMediaType()))
-            .build()
-            .create(FactService::class.java)
-}

--- a/app/src/main/java/jp/speakbuddy/edisonandroidexercise/ui/fact/FactScreen.kt
+++ b/app/src/main/java/jp/speakbuddy/edisonandroidexercise/ui/fact/FactScreen.kt
@@ -61,6 +61,7 @@ fun FactScreen(
 @Composable
 private fun FactScreenPreview() {
     EdisonAndroidExerciseTheme {
-        FactScreen(viewModel = FactViewModel())
+        // TODO Martin: Update FactViewModel later, currently it's hard to use
+//        FactScreen(viewModel = FactViewModel())
     }
 }

--- a/app/src/main/java/jp/speakbuddy/edisonandroidexercise/ui/fact/FactViewModel.kt
+++ b/app/src/main/java/jp/speakbuddy/edisonandroidexercise/ui/fact/FactViewModel.kt
@@ -1,14 +1,19 @@
 package jp.speakbuddy.edisonandroidexercise.ui.fact
 
 import androidx.lifecycle.ViewModel
-import jp.speakbuddy.edisonandroidexercise.network.FactServiceProvider
+import dagger.hilt.android.lifecycle.HiltViewModel
+import jp.speakbuddy.edisonandroidexercise.network.FactService
 import kotlinx.coroutines.runBlocking
+import javax.inject.Inject
 
-class FactViewModel : ViewModel() {
+@HiltViewModel
+class FactViewModel @Inject constructor(
+    private val factService: FactService,
+) : ViewModel() {
     fun updateFact(completion: () -> Unit): String =
         runBlocking {
             try {
-                FactServiceProvider.provide().getFact().fact
+                factService.getFact().fact
             } catch (e: Throwable) {
                 "something went wrong. error = ${e.message}"
             }.also { completion() }

--- a/app/src/test/java/jp/speakbuddy/edisonandroidexercise/ui/FactViewModelTest.kt
+++ b/app/src/test/java/jp/speakbuddy/edisonandroidexercise/ui/FactViewModelTest.kt
@@ -1,11 +1,13 @@
 package jp.speakbuddy.edisonandroidexercise.ui
 
+import io.mockk.mockk
+import jp.speakbuddy.edisonandroidexercise.network.FactService
 import jp.speakbuddy.edisonandroidexercise.ui.fact.FactViewModel
 import org.junit.Test
 
 class FactViewModelTest {
-
-    private val viewModel = FactViewModel()
+    private val factService: FactService = mockk(relaxed = true)
+    private val viewModel = FactViewModel(factService)
 
     @Test
     fun updateFact() {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,6 +14,7 @@ retrofit = "2.11.0"
 junit = "4.13.2"
 androidx-junit = "1.2.1"
 espresso = "3.6.1"
+mockk = "1.13.13"
 
 android-gradle-plugin = "8.4.2"
 kotlin = "2.0.21"
@@ -41,6 +42,7 @@ espresso = { module = "androidx.test.espresso:espresso-core", version.ref = "esp
 ui-test-junit4 = { module = "androidx.compose.ui:ui-test-junit4", version.ref = "compose-ui" }
 ui-tooling = { module = "androidx.compose.ui:ui-tooling", version.ref = "compose-ui" }
 ui-test-manifest = { module = "androidx.compose.ui:ui-test-manifest", version.ref = "compose-ui" }
+mockk = { module = "io.mockk:mockk", version.ref = "mockk" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "android-gradle-plugin" }


### PR DESCRIPTION
## Description
This PR updates implementation for VM to make it injectable from activity (also update activity to inject the VM)
In this PR the CI/CD might break because we remove the FactServiceProvider and now we inject the FactService to VM directly (which will be updated in the later PRs)
To make the unit tests runs well, we add dependencies to [mockk](https://mockk.io/ANDROID.html) that helps mocking on tests so we can just use mock data to FactService