### PR TITLE
Martin/add fact network data source

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -75,6 +75,7 @@ dependencies {
     implementation(libs.datastore.preferences)
     implementation(libs.hilt.android)
     implementation(libs.lifecycle.runtime.ktx)
+    implementation(libs.lifecycle.viewmodel.compose)
     implementation(libs.material3)
     implementation(libs.okhttp)
     implementation(libs.protobuf.kotlin.lite)
@@ -86,7 +87,9 @@ dependencies {
     kapt(libs.hilt.compiler)
 
     testImplementation(libs.junit)
+    testImplementation(libs.coroutine.test)
     testImplementation(libs.mockk)
+    testImplementation(libs.turbine)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.espresso)
     androidTestImplementation(libs.ui.test.junit4)

--- a/app/src/main/java/jp/speakbuddy/edisonandroidexercise/MainActivity.kt
+++ b/app/src/main/java/jp/speakbuddy/edisonandroidexercise/MainActivity.kt
@@ -9,13 +9,13 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.ui.Modifier
 import dagger.hilt.android.AndroidEntryPoint
+import jp.speakbuddy.edisonandroidexercise.ui.fact.FactRoute
 import jp.speakbuddy.edisonandroidexercise.ui.fact.FactScreen
 import jp.speakbuddy.edisonandroidexercise.ui.fact.FactViewModel
 import jp.speakbuddy.edisonandroidexercise.ui.theme.EdisonAndroidExerciseTheme
 
 @AndroidEntryPoint
 class MainActivity : ComponentActivity() {
-    private val factViewModel: FactViewModel by viewModels()
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContent {
@@ -25,7 +25,7 @@ class MainActivity : ComponentActivity() {
                     modifier = Modifier.fillMaxSize(),
                     color = MaterialTheme.colorScheme.background
                 ) {
-                    FactScreen(viewModel = factViewModel)
+                    FactRoute()
                 }
             }
         }

--- a/app/src/main/java/jp/speakbuddy/edisonandroidexercise/common/DispatcherProvider.kt
+++ b/app/src/main/java/jp/speakbuddy/edisonandroidexercise/common/DispatcherProvider.kt
@@ -1,0 +1,17 @@
+package jp.speakbuddy.edisonandroidexercise.common
+
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import javax.inject.Inject
+
+interface DispatcherProvider {
+    val io: CoroutineDispatcher
+    val main: CoroutineDispatcher
+    val default: CoroutineDispatcher
+}
+
+class DefaultDispatcherProvider @Inject constructor() : DispatcherProvider {
+    override val io: CoroutineDispatcher = Dispatchers.IO
+    override val main: CoroutineDispatcher = Dispatchers.Main
+    override val default: CoroutineDispatcher = Dispatchers.Default
+}

--- a/app/src/main/java/jp/speakbuddy/edisonandroidexercise/common/di/CommonProvider.kt
+++ b/app/src/main/java/jp/speakbuddy/edisonandroidexercise/common/di/CommonProvider.kt
@@ -1,0 +1,17 @@
+package jp.speakbuddy.edisonandroidexercise.common.di
+
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import jp.speakbuddy.edisonandroidexercise.common.DefaultDispatcherProvider
+import jp.speakbuddy.edisonandroidexercise.common.DispatcherProvider
+
+@Module
+@InstallIn(SingletonComponent::class)
+object CommonProvider {
+    @Provides
+    fun provideDispatcherProvider(defaultDispatcherProvider: DefaultDispatcherProvider) : DispatcherProvider {
+        return defaultDispatcherProvider
+    }
+}

--- a/app/src/main/java/jp/speakbuddy/edisonandroidexercise/data/FactResponse.kt
+++ b/app/src/main/java/jp/speakbuddy/edisonandroidexercise/data/FactResponse.kt
@@ -1,0 +1,9 @@
+package jp.speakbuddy.edisonandroidexercise.data
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class FactResponse(
+    val fact: String,
+    val length: Int
+)

--- a/app/src/main/java/jp/speakbuddy/edisonandroidexercise/dev_plan.md
+++ b/app/src/main/java/jp/speakbuddy/edisonandroidexercise/dev_plan.md
@@ -37,7 +37,7 @@
     - Update Service Provider (use Hilt) :white_check_mark:
     - Update FactViewModel to use serviceProvider and enable DI :white_check_mark:
     - Inject ViewModel on Activity :white_check_mark:
-- Consider moving FactResponse to separate class
+- Consider moving FactResponse to separate class :white_check_mark:
 - Add FactEntity
 - Add FactLocalDataSource
 - Add FactNetworkDataSource

--- a/app/src/main/java/jp/speakbuddy/edisonandroidexercise/dev_plan.md
+++ b/app/src/main/java/jp/speakbuddy/edisonandroidexercise/dev_plan.md
@@ -40,7 +40,7 @@
 - Consider moving FactResponse to separate class :white_check_mark:
 - Add FactEntity
 - Add FactLocalDataSource
-- Add FactNetworkDataSource
+- Add FactNetworkDataSource :white_check_mark:
 - Add FactData
 - Add FactRepository
 - Update FactViewModel to use FactRepository

--- a/app/src/main/java/jp/speakbuddy/edisonandroidexercise/network/FactService.kt
+++ b/app/src/main/java/jp/speakbuddy/edisonandroidexercise/network/FactService.kt
@@ -7,9 +7,3 @@ interface FactService {
     @GET("fact")
     suspend fun getFact(): FactResponse
 }
-
-@Serializable
-data class FactResponse(
-    val fact: String,
-    val length: Int
-)

--- a/app/src/main/java/jp/speakbuddy/edisonandroidexercise/network/FactService.kt
+++ b/app/src/main/java/jp/speakbuddy/edisonandroidexercise/network/FactService.kt
@@ -1,6 +1,6 @@
 package jp.speakbuddy.edisonandroidexercise.network
 
-import kotlinx.serialization.Serializable
+import jp.speakbuddy.edisonandroidexercise.data.FactResponse
 import retrofit2.http.GET
 
 interface FactService {

--- a/app/src/main/java/jp/speakbuddy/edisonandroidexercise/network/datasource/FactNetworkDataSource.kt
+++ b/app/src/main/java/jp/speakbuddy/edisonandroidexercise/network/datasource/FactNetworkDataSource.kt
@@ -1,0 +1,7 @@
+package jp.speakbuddy.edisonandroidexercise.network.datasource
+
+import jp.speakbuddy.edisonandroidexercise.data.FactResponse
+
+interface FactNetworkDataSource {
+    suspend fun getFact(): Result<FactResponse>
+}

--- a/app/src/main/java/jp/speakbuddy/edisonandroidexercise/network/datasource/FactNetworkDataSourceImpl.kt
+++ b/app/src/main/java/jp/speakbuddy/edisonandroidexercise/network/datasource/FactNetworkDataSourceImpl.kt
@@ -8,8 +8,6 @@ class FactNetworkDataSourceImpl @Inject constructor(
     private val factService: FactService,
 ): FactNetworkDataSource {
     override suspend fun getFact(): Result<FactResponse> {
-        return runCatching {
-            factService.getFact()
-        }
+        return runCatching { factService.getFact() }
     }
 }

--- a/app/src/main/java/jp/speakbuddy/edisonandroidexercise/network/datasource/FactNetworkDataSourceImpl.kt
+++ b/app/src/main/java/jp/speakbuddy/edisonandroidexercise/network/datasource/FactNetworkDataSourceImpl.kt
@@ -1,0 +1,15 @@
+package jp.speakbuddy.edisonandroidexercise.network.datasource
+
+import jp.speakbuddy.edisonandroidexercise.data.FactResponse
+import jp.speakbuddy.edisonandroidexercise.network.FactService
+import javax.inject.Inject
+
+class FactNetworkDataSourceImpl @Inject constructor(
+    private val factService: FactService,
+): FactNetworkDataSource {
+    override suspend fun getFact(): Result<FactResponse> {
+        return runCatching {
+            factService.getFact()
+        }
+    }
+}

--- a/app/src/main/java/jp/speakbuddy/edisonandroidexercise/network/di/NetworkModule.kt
+++ b/app/src/main/java/jp/speakbuddy/edisonandroidexercise/network/di/NetworkModule.kt
@@ -6,6 +6,8 @@ import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import jp.speakbuddy.edisonandroidexercise.network.FactService
+import jp.speakbuddy.edisonandroidexercise.network.datasource.FactNetworkDataSource
+import jp.speakbuddy.edisonandroidexercise.network.datasource.FactNetworkDataSourceImpl
 import kotlinx.serialization.json.Json
 import okhttp3.MediaType.Companion.toMediaType
 import retrofit2.Converter
@@ -30,5 +32,10 @@ object NetworkModule {
     @Provides
     fun provideJsonConverterFactory(): Converter.Factory {
         return Json.asConverterFactory("application/json".toMediaType())
+    }
+
+    @Provides
+    fun provideFactNetworkDataSource(factNetworkDataSourceImpl: FactNetworkDataSourceImpl): FactNetworkDataSource {
+        return factNetworkDataSourceImpl
     }
 }

--- a/app/src/main/java/jp/speakbuddy/edisonandroidexercise/ui/fact/FactScreen.kt
+++ b/app/src/main/java/jp/speakbuddy/edisonandroidexercise/ui/fact/FactScreen.kt
@@ -6,10 +6,10 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Button
-import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -18,14 +18,56 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.viewmodel.compose.viewModel
 import jp.speakbuddy.edisonandroidexercise.ui.theme.EdisonAndroidExerciseTheme
 
 @Composable
+fun FactRoute(
+    modifier: Modifier = Modifier,
+    factViewModel: FactViewModel = viewModel(),
+) {
+    val uiState by factViewModel.uiState.collectAsStateWithLifecycle()
+
+    // initialize data
+    LaunchedEffect(Unit) {
+        factViewModel.updateFact()
+    }
+
+    FactScreen(
+        modifier,
+        uiState,
+        factViewModel::updateFact
+    )
+}
+
+@Composable
 fun FactScreen(
-    viewModel: FactViewModel
+    modifier: Modifier = Modifier,
+    uiState: FactUiState,
+    onRefreshClicked: () -> Unit,
+) {
+    when (uiState) {
+        is FactUiState.Content -> {
+            FactContent(factContent = uiState, onRefreshClicked = onRefreshClicked)
+        }
+        is FactUiState.Error -> {
+            // TODO add Error screen later
+        }
+        FactUiState.Loading -> {
+            // TODO add loading mechanism
+        }
+    }
+}
+
+@Composable
+fun FactContent(
+    modifier: Modifier = Modifier,
+    factContent: FactUiState.Content,
+    onRefreshClicked: () -> Unit,
 ) {
     Column(
-        modifier = Modifier
+        modifier = modifier
             .fillMaxSize()
             .background(MaterialTheme.colorScheme.background)
             .padding(16.dp),
@@ -35,23 +77,17 @@ fun FactScreen(
             alignment = Alignment.CenterVertically
         )
     ) {
-        var fact by remember { mutableStateOf("") }
-
         Text(
             text = "Fact",
             style = MaterialTheme.typography.titleLarge
         )
 
         Text(
-            text = fact,
+            text = factContent.fact,
             style = MaterialTheme.typography.bodyLarge
         )
 
-        val onClick = {
-            fact = viewModel.updateFact { print("done") }
-        }
-
-        Button(onClick = onClick) {
+        Button(onClick = onRefreshClicked) {
             Text(text = "Update fact")
         }
     }
@@ -61,7 +97,6 @@ fun FactScreen(
 @Composable
 private fun FactScreenPreview() {
     EdisonAndroidExerciseTheme {
-        // TODO Martin: Update FactViewModel later, currently it's hard to use
-//        FactScreen(viewModel = FactViewModel())
+        FactScreen(uiState = FactUiState.Content("This is sample facts"), onRefreshClicked = { })
     }
 }

--- a/app/src/main/java/jp/speakbuddy/edisonandroidexercise/ui/fact/FactUiState.kt
+++ b/app/src/main/java/jp/speakbuddy/edisonandroidexercise/ui/fact/FactUiState.kt
@@ -1,0 +1,15 @@
+package jp.speakbuddy.edisonandroidexercise.ui.fact
+
+sealed interface FactUiState {
+    companion object {
+        val INITIAL = Loading
+    }
+    data object Loading: FactUiState
+    data class Content(
+        val fact: String,
+    ) : FactUiState
+
+    data class Error(
+        val errorMessage: String
+    ) : FactUiState
+}

--- a/app/src/main/java/jp/speakbuddy/edisonandroidexercise/ui/fact/FactViewModel.kt
+++ b/app/src/main/java/jp/speakbuddy/edisonandroidexercise/ui/fact/FactViewModel.kt
@@ -1,21 +1,38 @@
 package jp.speakbuddy.edisonandroidexercise.ui.fact
 
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
-import jp.speakbuddy.edisonandroidexercise.network.FactService
-import kotlinx.coroutines.runBlocking
+import jp.speakbuddy.edisonandroidexercise.common.DispatcherProvider
+import jp.speakbuddy.edisonandroidexercise.network.datasource.FactNetworkDataSource
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
 class FactViewModel @Inject constructor(
-    private val factService: FactService,
+    private val factNetworkDataSource: FactNetworkDataSource,
+    private val dispatcherProvider: DispatcherProvider,
 ) : ViewModel() {
-    fun updateFact(completion: () -> Unit): String =
-        runBlocking {
-            try {
-                factService.getFact().fact
-            } catch (e: Throwable) {
-                "something went wrong. error = ${e.message}"
-            }.also { completion() }
+    private val _uiState: MutableStateFlow<FactUiState> = MutableStateFlow(FactUiState.INITIAL)
+    val uiState = _uiState.asStateFlow()
+
+    fun updateFact() {
+        viewModelScope.launch(dispatcherProvider.main) {
+            factNetworkDataSource.getFact()
+                .onSuccess { factResponse ->
+                    _uiState.update {
+                        FactUiState.Content(factResponse.fact)
+                    }
+                }
+                .onFailure { throwable ->
+                    // TODO update error message later
+                    _uiState.update {
+                        FactUiState.Error("Dummy Error Message now")
+                    }
+                }
         }
+    }
 }

--- a/app/src/test/java/jp/speakbuddy/edisonandroidexercise/network/datasource/FactNetworkDataSourceImplTest.kt
+++ b/app/src/test/java/jp/speakbuddy/edisonandroidexercise/network/datasource/FactNetworkDataSourceImplTest.kt
@@ -1,0 +1,54 @@
+package jp.speakbuddy.edisonandroidexercise.network.datasource
+
+import io.mockk.clearAllMocks
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import jp.speakbuddy.edisonandroidexercise.data.FactResponse
+import jp.speakbuddy.edisonandroidexercise.network.FactService
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import java.io.IOException
+
+@ExperimentalCoroutinesApi
+class FactNetworkDataSourceImplTest {
+    private val factService: FactService = mockk()
+
+    private lateinit var factNetworkDataSourceImpl: FactNetworkDataSourceImpl
+
+    @Before
+    fun setup() {
+        factNetworkDataSourceImpl = FactNetworkDataSourceImpl(factService)
+    }
+    @After
+    fun tearDown() {
+        clearAllMocks()
+    }
+
+    @Test
+    fun `when getFact is successful should return Result success correctly`() = runTest {
+        val expectedFact = FactResponse(fact = "Facts", length = 5)
+        coEvery{ factService.getFact() } returns expectedFact
+
+        val actualFact = factNetworkDataSourceImpl.getFact()
+
+        assertEquals(Result.success(expectedFact), actualFact)
+        coVerify { factService.getFact() }
+    }
+
+    @Test
+    fun `when getFact is failed should return Result failure`() = runTest {
+        val expectedThrowable = IOException()
+        coEvery{ factService.getFact() } throws expectedThrowable
+
+        val actualFact = factNetworkDataSourceImpl.getFact()
+
+        assertEquals(Result.failure<FactResponse>(expectedThrowable), actualFact)
+        coVerify { factService.getFact() }
+    }
+
+}

--- a/app/src/test/java/jp/speakbuddy/edisonandroidexercise/ui/FactViewModelTest.kt
+++ b/app/src/test/java/jp/speakbuddy/edisonandroidexercise/ui/FactViewModelTest.kt
@@ -1,23 +1,58 @@
 package jp.speakbuddy.edisonandroidexercise.ui
 
+import app.cash.turbine.test
+import io.mockk.clearAllMocks
+import io.mockk.coEvery
 import io.mockk.mockk
-import jp.speakbuddy.edisonandroidexercise.network.FactService
+import jp.speakbuddy.edisonandroidexercise.common.DispatcherProvider
+import jp.speakbuddy.edisonandroidexercise.data.FactResponse
+import jp.speakbuddy.edisonandroidexercise.network.datasource.FactNetworkDataSource
+import jp.speakbuddy.edisonandroidexercise.ui.common.DefaultTestDispatcherProvider
+import jp.speakbuddy.edisonandroidexercise.ui.fact.FactUiState
 import jp.speakbuddy.edisonandroidexercise.ui.fact.FactViewModel
+import junit.framework.TestCase.assertEquals
+import kotlinx.coroutines.test.runTest
+import org.junit.After
 import org.junit.Test
+import java.io.IOException
 
 class FactViewModelTest {
-    private val factService: FactService = mockk(relaxed = true)
-    private val viewModel = FactViewModel(factService)
+    private val factNetworkDataSource: FactNetworkDataSource = mockk()
+    private val dispatcherProvider: DispatcherProvider = DefaultTestDispatcherProvider()
+    private val viewModel = FactViewModel(factNetworkDataSource, dispatcherProvider)
+
+    @After
+    fun afterEach() {
+        clearAllMocks()
+    }
 
     @Test
-    fun updateFact() {
-        var loading = true
-        val initialFact = "initial"
-        var fact = initialFact
+    fun `when updateFact is triggered and fetchNetwork Success, should return ui state with facts correctly`() = runTest {
+        val newFact = "New Facts"
+        coEvery { factNetworkDataSource.getFact() } returns Result.success(
+            FactResponse(
+                length = newFact.length,
+                fact = newFact
+            )
+        )
 
-        fact = viewModel.updateFact { loading = false }
+        viewModel.uiState.test {
+            assertEquals(FactUiState.INITIAL, awaitItem())
+            viewModel.updateFact()
+            assertEquals(FactUiState.Content(newFact), awaitItem())
+            ensureAllEventsConsumed()
+        }
+    }
 
-        assert(!loading)
-        assert(fact != initialFact)
+    @Test
+    fun `when updateFact is triggered and fetchNetwork Failure, should return ui state with facts correctly`() = runTest {
+        coEvery { factNetworkDataSource.getFact() } returns Result.failure(IOException())
+
+        viewModel.uiState.test {
+            assertEquals(FactUiState.INITIAL, awaitItem())
+            viewModel.updateFact()
+            assertEquals(FactUiState.Error("Dummy Error Message now"), awaitItem())
+            ensureAllEventsConsumed()
+        }
     }
 }

--- a/app/src/test/java/jp/speakbuddy/edisonandroidexercise/ui/common/DefaultTestDispatcherProvider.kt
+++ b/app/src/test/java/jp/speakbuddy/edisonandroidexercise/ui/common/DefaultTestDispatcherProvider.kt
@@ -1,0 +1,12 @@
+package jp.speakbuddy.edisonandroidexercise.ui.common
+
+import jp.speakbuddy.edisonandroidexercise.common.DispatcherProvider
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+
+class DefaultTestDispatcherProvider @OptIn(ExperimentalCoroutinesApi::class) constructor(
+    override val io: CoroutineDispatcher = UnconfinedTestDispatcher(),
+    override val main: CoroutineDispatcher = UnconfinedTestDispatcher(),
+    override val default: CoroutineDispatcher = UnconfinedTestDispatcher(),
+) : DispatcherProvider

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -15,6 +15,7 @@ junit = "4.13.2"
 androidx-junit = "1.2.1"
 espresso = "3.6.1"
 mockk = "1.13.13"
+turbine = "1.2.0"
 
 android-gradle-plugin = "8.4.2"
 kotlin = "2.0.21"
@@ -23,6 +24,7 @@ protobuf-plugin = "0.9.4"
 [libraries]
 core-ktx = { module = "androidx.core:core-ktx", version.ref = "androidx-core-ktx" }
 lifecycle-runtime-ktx = { module = "androidx.lifecycle:lifecycle-runtime-ktx", version.ref = "lifecycle-runtime-ktx" }
+lifecycle-viewmodel-compose = { module = "androidx.lifecycle:lifecycle-viewmodel-compose", version.ref = "lifecycle-runtime-ktx" }
 activity-compose = { module = "androidx.activity:activity-compose", version.ref = "activity-compose" }
 compose-ui = { module = "androidx.compose.ui:ui", version.ref = "compose-ui" }
 ui-tooling-preview = { module = "androidx.compose.ui:ui-tooling-preview", version.ref = "compose-ui" }
@@ -43,6 +45,8 @@ ui-test-junit4 = { module = "androidx.compose.ui:ui-test-junit4", version.ref = 
 ui-tooling = { module = "androidx.compose.ui:ui-tooling", version.ref = "compose-ui" }
 ui-test-manifest = { module = "androidx.compose.ui:ui-test-manifest", version.ref = "compose-ui" }
 mockk = { module = "io.mockk:mockk", version.ref = "mockk" }
+turbine = {module = "app.cash.turbine:turbine", version.ref ="turbine" }
+coroutine-test = {module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version = "1.9.0" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "android-gradle-plugin" }


### PR DESCRIPTION
## Description
This PR adds implementation for FactNetworkDataSource, which encapsulate data source for facts that comes from network
To improve abstraction layer for returning/retrieving the data, I changed the return value for the function to use Result class, which help to encapsulate whether the request is successful or not

In this PR too I changed the implementation of the ViewModel so that we got a single data source for the UI, making sure all of the UI data is available in that one single class

As we add more logic on the ViewModel and the DataSource now, I added a turbine library here to help with testing the flow (which is now heavily used in the ViewModel)