### PR TITLE
Add Fact Local Data Source

### DIFF
--- a/app/src/main/java/jp/speakbuddy/edisonandroidexercise/common/di/CommonProvider.kt
+++ b/app/src/main/java/jp/speakbuddy/edisonandroidexercise/common/di/CommonProvider.kt
@@ -1,7 +1,7 @@
 package jp.speakbuddy.edisonandroidexercise.common.di
 
+import dagger.Binds
 import dagger.Module
-import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import jp.speakbuddy.edisonandroidexercise.common.DefaultDispatcherProvider
@@ -9,9 +9,7 @@ import jp.speakbuddy.edisonandroidexercise.common.DispatcherProvider
 
 @Module
 @InstallIn(SingletonComponent::class)
-object CommonProvider {
-    @Provides
-    fun provideDispatcherProvider(defaultDispatcherProvider: DefaultDispatcherProvider) : DispatcherProvider {
-        return defaultDispatcherProvider
-    }
+abstract class CommonProvider {
+    @Binds
+    abstract fun provideDispatcherProvider(defaultDispatcherProvider: DefaultDispatcherProvider) : DispatcherProvider
 }

--- a/app/src/main/java/jp/speakbuddy/edisonandroidexercise/dev_plan.md
+++ b/app/src/main/java/jp/speakbuddy/edisonandroidexercise/dev_plan.md
@@ -38,8 +38,8 @@
     - Update FactViewModel to use serviceProvider and enable DI :white_check_mark:
     - Inject ViewModel on Activity :white_check_mark:
 - Consider moving FactResponse to separate class :white_check_mark:
-- Add FactEntity
-- Add FactLocalDataSource
+- Add FactEntity :white_check_mark:
+- Add FactLocalDataSource :white_check_mark:
 - Add FactNetworkDataSource :white_check_mark:
 - Add FactData
 - Add FactRepository

--- a/app/src/main/java/jp/speakbuddy/edisonandroidexercise/local/data/FactEntity.kt
+++ b/app/src/main/java/jp/speakbuddy/edisonandroidexercise/local/data/FactEntity.kt
@@ -1,0 +1,9 @@
+package jp.speakbuddy.edisonandroidexercise.local.data
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class FactEntity(
+    val fact: String = "",
+    val length: Int = 0,
+)

--- a/app/src/main/java/jp/speakbuddy/edisonandroidexercise/local/data/FactEntitySerializer.kt
+++ b/app/src/main/java/jp/speakbuddy/edisonandroidexercise/local/data/FactEntitySerializer.kt
@@ -1,0 +1,39 @@
+package jp.speakbuddy.edisonandroidexercise.local.data
+
+import androidx.datastore.core.Serializer
+import jp.speakbuddy.edisonandroidexercise.common.DispatcherProvider
+import kotlinx.coroutines.withContext
+import kotlinx.serialization.json.Json
+import java.io.InputStream
+import java.io.OutputStream
+import javax.inject.Inject
+
+class FactEntitySerializer @Inject constructor(
+    private val dispatcherProvider: DispatcherProvider,
+): Serializer<FactEntity> {
+    override val defaultValue: FactEntity
+        get() = FactEntity()
+
+    override suspend fun readFrom(input: InputStream): FactEntity {
+        return try {
+            Json.decodeFromString(
+                deserializer = FactEntity.serializer(),
+                string = input.readBytes().decodeToString()
+            )
+        } catch (e: Exception) {
+            e.printStackTrace()
+            defaultValue
+        }
+    }
+
+    override suspend fun writeTo(t: FactEntity, output: OutputStream) {
+        withContext(dispatcherProvider.io) {
+            output.write(
+                Json.encodeToString(
+                    serializer = FactEntity.serializer(),
+                    value = t,
+                ).encodeToByteArray()
+            )
+        }
+    }
+}

--- a/app/src/main/java/jp/speakbuddy/edisonandroidexercise/local/datasource/FactLocalDataSource.kt
+++ b/app/src/main/java/jp/speakbuddy/edisonandroidexercise/local/datasource/FactLocalDataSource.kt
@@ -1,0 +1,8 @@
+package jp.speakbuddy.edisonandroidexercise.local.datasource
+
+import jp.speakbuddy.edisonandroidexercise.local.data.FactEntity
+
+interface FactLocalDataSource {
+    suspend fun getFact(): FactEntity
+    suspend fun updateFact(factEntity: FactEntity)
+}

--- a/app/src/main/java/jp/speakbuddy/edisonandroidexercise/local/datasource/FactLocalProtoDataSourceImpl.kt
+++ b/app/src/main/java/jp/speakbuddy/edisonandroidexercise/local/datasource/FactLocalProtoDataSourceImpl.kt
@@ -1,0 +1,16 @@
+package jp.speakbuddy.edisonandroidexercise.local.datasource
+
+import androidx.datastore.core.DataStore
+import jp.speakbuddy.edisonandroidexercise.local.data.FactEntity
+import kotlinx.coroutines.flow.firstOrNull
+import javax.inject.Inject
+
+class FactLocalProtoDataSourceImpl @Inject constructor(
+    private val factDataStore: DataStore<FactEntity>,
+): FactLocalDataSource {
+    override suspend fun getFact(): FactEntity = factDataStore.data.firstOrNull() ?: FactEntity()
+
+    override suspend fun updateFact(factEntity: FactEntity) {
+        factDataStore.updateData { factEntity }
+    }
+}

--- a/app/src/main/java/jp/speakbuddy/edisonandroidexercise/local/di/LocalDataModule.kt
+++ b/app/src/main/java/jp/speakbuddy/edisonandroidexercise/local/di/LocalDataModule.kt
@@ -1,0 +1,44 @@
+package jp.speakbuddy.edisonandroidexercise.local.di
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.core.DataStoreFactory
+import androidx.datastore.dataStoreFile
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.components.SingletonComponent
+import jp.speakbuddy.edisonandroidexercise.common.DispatcherProvider
+import jp.speakbuddy.edisonandroidexercise.local.data.FactEntity
+import jp.speakbuddy.edisonandroidexercise.local.data.FactEntitySerializer
+import jp.speakbuddy.edisonandroidexercise.local.datasource.FactLocalDataSource
+import jp.speakbuddy.edisonandroidexercise.local.datasource.FactLocalProtoDataSourceImpl
+import kotlinx.coroutines.CoroutineScope
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+object LocalDataModule {
+    @Provides
+    @Singleton
+    fun provideFactDataStore(
+        @ApplicationContext context: Context,
+        dispatcherProvider: DispatcherProvider,
+        factEntitySerializer: FactEntitySerializer,
+    ): DataStore<FactEntity> {
+        return DataStoreFactory.create(
+            serializer = factEntitySerializer,
+            scope = CoroutineScope(dispatcherProvider.io),
+            migrations = listOf(),
+        ) {
+            context.dataStoreFile("fact_data_store.json")
+        }
+    }
+
+    @Provides
+    @Singleton
+    fun provideFactLocalDataSource(factLocalProtoDataSourceImpl: FactLocalProtoDataSourceImpl): FactLocalDataSource {
+        return factLocalProtoDataSourceImpl
+    }
+}

--- a/app/src/main/java/jp/speakbuddy/edisonandroidexercise/model/FactModel.kt
+++ b/app/src/main/java/jp/speakbuddy/edisonandroidexercise/model/FactModel.kt
@@ -1,0 +1,6 @@
+package jp.speakbuddy.edisonandroidexercise.model
+
+data class FactModel(
+    val fact: String,
+    val length: Int,
+)

--- a/app/src/main/java/jp/speakbuddy/edisonandroidexercise/network/FactService.kt
+++ b/app/src/main/java/jp/speakbuddy/edisonandroidexercise/network/FactService.kt
@@ -1,6 +1,6 @@
 package jp.speakbuddy.edisonandroidexercise.network
 
-import jp.speakbuddy.edisonandroidexercise.data.FactResponse
+import jp.speakbuddy.edisonandroidexercise.network.data.FactResponse
 import retrofit2.http.GET
 
 interface FactService {

--- a/app/src/main/java/jp/speakbuddy/edisonandroidexercise/network/data/FactResponse.kt
+++ b/app/src/main/java/jp/speakbuddy/edisonandroidexercise/network/data/FactResponse.kt
@@ -1,4 +1,4 @@
-package jp.speakbuddy.edisonandroidexercise.data
+package jp.speakbuddy.edisonandroidexercise.network.data
 
 import kotlinx.serialization.Serializable
 

--- a/app/src/main/java/jp/speakbuddy/edisonandroidexercise/network/datasource/FactNetworkDataSource.kt
+++ b/app/src/main/java/jp/speakbuddy/edisonandroidexercise/network/datasource/FactNetworkDataSource.kt
@@ -1,6 +1,6 @@
 package jp.speakbuddy.edisonandroidexercise.network.datasource
 
-import jp.speakbuddy.edisonandroidexercise.data.FactResponse
+import jp.speakbuddy.edisonandroidexercise.network.data.FactResponse
 
 interface FactNetworkDataSource {
     suspend fun getFact(): Result<FactResponse>

--- a/app/src/main/java/jp/speakbuddy/edisonandroidexercise/network/datasource/FactNetworkDataSourceImpl.kt
+++ b/app/src/main/java/jp/speakbuddy/edisonandroidexercise/network/datasource/FactNetworkDataSourceImpl.kt
@@ -1,7 +1,7 @@
 package jp.speakbuddy.edisonandroidexercise.network.datasource
 
-import jp.speakbuddy.edisonandroidexercise.data.FactResponse
 import jp.speakbuddy.edisonandroidexercise.network.FactService
+import jp.speakbuddy.edisonandroidexercise.network.data.FactResponse
 import javax.inject.Inject
 
 class FactNetworkDataSourceImpl @Inject constructor(

--- a/app/src/main/java/jp/speakbuddy/edisonandroidexercise/ui/fact/FactViewModel.kt
+++ b/app/src/main/java/jp/speakbuddy/edisonandroidexercise/ui/fact/FactViewModel.kt
@@ -4,8 +4,6 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import jp.speakbuddy.edisonandroidexercise.common.DispatcherProvider
-import jp.speakbuddy.edisonandroidexercise.local.data.FactEntity
-import jp.speakbuddy.edisonandroidexercise.network.data.FactResponse
 import jp.speakbuddy.edisonandroidexercise.network.datasource.FactNetworkDataSource
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -38,5 +36,3 @@ class FactViewModel @Inject constructor(
         }
     }
 }
-
-private fun FactResponse.toEntity() = FactEntity(fact, length)

--- a/app/src/main/java/jp/speakbuddy/edisonandroidexercise/ui/fact/FactViewModel.kt
+++ b/app/src/main/java/jp/speakbuddy/edisonandroidexercise/ui/fact/FactViewModel.kt
@@ -4,6 +4,9 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import jp.speakbuddy.edisonandroidexercise.common.DispatcherProvider
+import jp.speakbuddy.edisonandroidexercise.local.data.FactEntity
+import jp.speakbuddy.edisonandroidexercise.local.datasource.FactLocalDataSource
+import jp.speakbuddy.edisonandroidexercise.network.data.FactResponse
 import jp.speakbuddy.edisonandroidexercise.network.datasource.FactNetworkDataSource
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -14,6 +17,7 @@ import javax.inject.Inject
 @HiltViewModel
 class FactViewModel @Inject constructor(
     private val factNetworkDataSource: FactNetworkDataSource,
+    private val factLocalDataSource: FactLocalDataSource,
     private val dispatcherProvider: DispatcherProvider,
 ) : ViewModel() {
     private val _uiState: MutableStateFlow<FactUiState> = MutableStateFlow(FactUiState.INITIAL)
@@ -23,6 +27,7 @@ class FactViewModel @Inject constructor(
         viewModelScope.launch(dispatcherProvider.main) {
             factNetworkDataSource.getFact()
                 .onSuccess { factResponse ->
+                    factLocalDataSource.updateFact(factResponse.toEntity())
                     _uiState.update {
                         FactUiState.Content(factResponse.fact)
                     }
@@ -36,3 +41,5 @@ class FactViewModel @Inject constructor(
         }
     }
 }
+
+private fun FactResponse.toEntity() = FactEntity(fact, length)

--- a/app/src/main/java/jp/speakbuddy/edisonandroidexercise/ui/fact/FactViewModel.kt
+++ b/app/src/main/java/jp/speakbuddy/edisonandroidexercise/ui/fact/FactViewModel.kt
@@ -5,7 +5,6 @@ import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import jp.speakbuddy.edisonandroidexercise.common.DispatcherProvider
 import jp.speakbuddy.edisonandroidexercise.local.data.FactEntity
-import jp.speakbuddy.edisonandroidexercise.local.datasource.FactLocalDataSource
 import jp.speakbuddy.edisonandroidexercise.network.data.FactResponse
 import jp.speakbuddy.edisonandroidexercise.network.datasource.FactNetworkDataSource
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -17,7 +16,6 @@ import javax.inject.Inject
 @HiltViewModel
 class FactViewModel @Inject constructor(
     private val factNetworkDataSource: FactNetworkDataSource,
-    private val factLocalDataSource: FactLocalDataSource,
     private val dispatcherProvider: DispatcherProvider,
 ) : ViewModel() {
     private val _uiState: MutableStateFlow<FactUiState> = MutableStateFlow(FactUiState.INITIAL)
@@ -27,7 +25,6 @@ class FactViewModel @Inject constructor(
         viewModelScope.launch(dispatcherProvider.main) {
             factNetworkDataSource.getFact()
                 .onSuccess { factResponse ->
-                    factLocalDataSource.updateFact(factResponse.toEntity())
                     _uiState.update {
                         FactUiState.Content(factResponse.fact)
                     }

--- a/app/src/test/java/jp/speakbuddy/edisonandroidexercise/local/data/FactEntitySerializerTest.kt
+++ b/app/src/test/java/jp/speakbuddy/edisonandroidexercise/local/data/FactEntitySerializerTest.kt
@@ -1,0 +1,66 @@
+package jp.speakbuddy.edisonandroidexercise.local.data
+
+import io.mockk.coEvery
+import io.mockk.mockkObject
+import jp.speakbuddy.edisonandroidexercise.common.DispatcherProvider
+import jp.speakbuddy.edisonandroidexercise.ui.common.DefaultTestDispatcherProvider
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+
+
+class FactEntitySerializerTest {
+
+    private val dispatcherProvider: DispatcherProvider = DefaultTestDispatcherProvider()
+    private lateinit var serializer: FactEntitySerializer
+
+    @Before
+    fun setup() {
+        serializer = FactEntitySerializer(dispatcherProvider)
+    }
+
+    @Test
+    fun testReadFrom_validInput_returnsFactEntity() = runTest {
+        // Arrange
+        val input = ByteArrayInputStream("""{"fact":"Test fact", "length": 20}""".toByteArray())
+
+        // Act
+        val result = serializer.readFrom(input)
+
+        // Assert
+        assertEquals(FactEntity("Test fact", 20), result)
+    }
+
+    @Test
+    fun testReadFrom_invalidInput_returnsDefaultValue() = runTest {
+        // Arrange
+        val input = ByteArrayInputStream("invalid json".toByteArray())
+
+        // Act
+        val result = serializer.readFrom(input)
+
+        // Assert
+        assertEquals(FactEntity(), result)
+    }
+
+    @Test
+    fun testWriteTo_writesFactEntityToOutputStream() = runTest {
+        // Arrange
+        val output = ByteArrayOutputStream()
+        val factEntity = FactEntity("Test fact", 20)
+        // not ideal, maybe consider wrapping json to another class, but for now should be good enough
+        mockkObject(Json) {
+            coEvery { Json.encodeToString(FactEntity.serializer(), factEntity) } returns """{"fact":"Test fact", "length": 20}"""
+        }
+
+        // Act
+        serializer.writeTo(factEntity, output)
+
+        // Assert
+        assertEquals("""{"fact":"Test fact","length":20}""", output.toString())
+    }
+}

--- a/app/src/test/java/jp/speakbuddy/edisonandroidexercise/local/datasource/FactLocalProtoDataSourceImplTest.kt
+++ b/app/src/test/java/jp/speakbuddy/edisonandroidexercise/local/datasource/FactLocalProtoDataSourceImplTest.kt
@@ -1,0 +1,69 @@
+package jp.speakbuddy.edisonandroidexercise.local.datasource
+import androidx.datastore.core.DataStore
+import io.mockk.Runs
+import io.mockk.clearAllMocks
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.just
+import io.mockk.mockk
+import jp.speakbuddy.edisonandroidexercise.local.data.FactEntity
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.firstOrNull
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class FactLocalProtoDataSourceImplTest {
+
+    private val factDataStore: DataStore<FactEntity> = mockk()
+    private val factLocalProtoDataSourceImpl = FactLocalProtoDataSourceImpl(factDataStore)
+
+    @After
+    fun tearDown() {
+        clearAllMocks()
+    }
+
+    @Test
+    fun `when get fact and fact is available, should return correct fact`() = runTest {
+        // Arrange
+        val expectedFact = FactEntity(fact = "Test fact")
+        coEvery { factDataStore.data } returns flowOf(expectedFact)
+
+        // Act
+        val actualFact = factLocalProtoDataSourceImpl.getFact()
+
+        // Assert
+        assertEquals(expectedFact, actualFact)
+    }
+
+    @Test
+    fun `when flow return null should return default value`() = runTest {
+        // Arrange
+        val expectedFact = FactEntity()
+        val mockFlow = mockk<Flow<FactEntity>>()
+        coEvery { mockFlow.firstOrNull() } returns null
+        coEvery { mockFlow.collect(any()) } just Runs
+        coEvery { factDataStore.data } returns mockFlow
+
+        // Act
+        val actualFact = factLocalProtoDataSourceImpl.getFact()
+
+        // Assert
+        assertEquals(expectedFact, actualFact)
+    }
+
+    @Test
+    fun `when updateFact should trigger update data to factDataStore correctly`() = runTest {
+        // Arrange
+        val factToUpdate = FactEntity(fact = "Updated fact")
+        coEvery { factDataStore.updateData(any()) } returns FactEntity()
+
+        // Act
+        factLocalProtoDataSourceImpl.updateFact(factToUpdate)
+
+        // Assert
+        coVerify { factDataStore.updateData(any()) }
+    }
+}

--- a/app/src/test/java/jp/speakbuddy/edisonandroidexercise/network/datasource/FactNetworkDataSourceImplTest.kt
+++ b/app/src/test/java/jp/speakbuddy/edisonandroidexercise/network/datasource/FactNetworkDataSourceImplTest.kt
@@ -4,8 +4,8 @@ import io.mockk.clearAllMocks
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.mockk
-import jp.speakbuddy.edisonandroidexercise.data.FactResponse
 import jp.speakbuddy.edisonandroidexercise.network.FactService
+import jp.speakbuddy.edisonandroidexercise.network.data.FactResponse
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.junit.After

--- a/app/src/test/java/jp/speakbuddy/edisonandroidexercise/ui/FactViewModelTest.kt
+++ b/app/src/test/java/jp/speakbuddy/edisonandroidexercise/ui/FactViewModelTest.kt
@@ -5,7 +5,7 @@ import io.mockk.clearAllMocks
 import io.mockk.coEvery
 import io.mockk.mockk
 import jp.speakbuddy.edisonandroidexercise.common.DispatcherProvider
-import jp.speakbuddy.edisonandroidexercise.data.FactResponse
+import jp.speakbuddy.edisonandroidexercise.network.data.FactResponse
 import jp.speakbuddy.edisonandroidexercise.network.datasource.FactNetworkDataSource
 import jp.speakbuddy.edisonandroidexercise.ui.common.DefaultTestDispatcherProvider
 import jp.speakbuddy.edisonandroidexercise.ui.fact.FactUiState


### PR DESCRIPTION
This PR adds implementation for local data storage
I decided to use DataStore because the handling for data is not that complex so instead of creating a whole room database which most of the function I don't need, implementing using DataStore is simpler
SharedPreferences can also be an option, but DataStore ensures the data being stored and fetch in suspending function and I think this is a good opportunity to learn about DataStore implementation

In this PR I also made several minor adjustments:
1. Move several classes to correct package (mostly data class as now we have local entity)
2. Change the Provider as an abstract instead (the provider class is quite simple to be provided