### PR TITLE
Add FactRepository and FactModel

### DIFF
--- a/app/src/main/java/jp/speakbuddy/edisonandroidexercise/dev_plan.md
+++ b/app/src/main/java/jp/speakbuddy/edisonandroidexercise/dev_plan.md
@@ -41,9 +41,9 @@
 - Add FactEntity :white_check_mark:
 - Add FactLocalDataSource :white_check_mark:
 - Add FactNetworkDataSource :white_check_mark:
-- Add FactData
-- Add FactRepository
-- Update FactViewModel to use FactRepository
+- Add FactData :white_check_mark: (renamed to FactModel)
+- Add FactRepository :white_check_mark:
+- Update FactViewModel to use FactRepository :white_check_mark:
 - Create FactDisplayMapper
     - Main Function -> Map FactData to FactDisplay Data
     - Add Fact Length (value with visibility?)

--- a/app/src/main/java/jp/speakbuddy/edisonandroidexercise/local/datasource/FactLocalDataSource.kt
+++ b/app/src/main/java/jp/speakbuddy/edisonandroidexercise/local/datasource/FactLocalDataSource.kt
@@ -3,6 +3,6 @@ package jp.speakbuddy.edisonandroidexercise.local.datasource
 import jp.speakbuddy.edisonandroidexercise.local.data.FactEntity
 
 interface FactLocalDataSource {
-    suspend fun getFact(): FactEntity
-    suspend fun updateFact(factEntity: FactEntity)
+    suspend fun getFact(): FactEntity?
+    suspend fun updateFact(factEntity: FactEntity): FactEntity
 }

--- a/app/src/main/java/jp/speakbuddy/edisonandroidexercise/local/datasource/FactLocalProtoDataSourceImpl.kt
+++ b/app/src/main/java/jp/speakbuddy/edisonandroidexercise/local/datasource/FactLocalProtoDataSourceImpl.kt
@@ -8,9 +8,9 @@ import javax.inject.Inject
 class FactLocalProtoDataSourceImpl @Inject constructor(
     private val factDataStore: DataStore<FactEntity>,
 ): FactLocalDataSource {
-    override suspend fun getFact(): FactEntity = factDataStore.data.firstOrNull() ?: FactEntity()
+    override suspend fun getFact(): FactEntity? = factDataStore.data.firstOrNull()
 
-    override suspend fun updateFact(factEntity: FactEntity) {
-        factDataStore.updateData { factEntity }
+    override suspend fun updateFact(factEntity: FactEntity): FactEntity {
+        return factDataStore.updateData { factEntity }
     }
 }

--- a/app/src/main/java/jp/speakbuddy/edisonandroidexercise/repository/FactRepository.kt
+++ b/app/src/main/java/jp/speakbuddy/edisonandroidexercise/repository/FactRepository.kt
@@ -1,0 +1,7 @@
+package jp.speakbuddy.edisonandroidexercise.repository
+
+import jp.speakbuddy.edisonandroidexercise.repository.model.FactModel
+
+interface FactRepository {
+    suspend fun getFact(forceFetch: Boolean): Result<FactModel>
+}

--- a/app/src/main/java/jp/speakbuddy/edisonandroidexercise/repository/OfflineFirstFactRepository.kt
+++ b/app/src/main/java/jp/speakbuddy/edisonandroidexercise/repository/OfflineFirstFactRepository.kt
@@ -1,0 +1,50 @@
+package jp.speakbuddy.edisonandroidexercise.repository
+
+import jp.speakbuddy.edisonandroidexercise.common.DispatcherProvider
+import jp.speakbuddy.edisonandroidexercise.local.data.FactEntity
+import jp.speakbuddy.edisonandroidexercise.local.datasource.FactLocalDataSource
+import jp.speakbuddy.edisonandroidexercise.network.data.FactResponse
+import jp.speakbuddy.edisonandroidexercise.network.datasource.FactNetworkDataSource
+import jp.speakbuddy.edisonandroidexercise.repository.model.FactModel
+import kotlinx.coroutines.withContext
+import java.io.IOException
+import javax.inject.Inject
+
+class OfflineFirstFactRepository @Inject constructor(
+    private val factNetworkDataSource: FactNetworkDataSource,
+    private val factLocalDataSource: FactLocalDataSource,
+    private val dispatcherProvider: DispatcherProvider,
+) : FactRepository {
+    override suspend fun getFact(forceFetch: Boolean): Result<FactModel> {
+        return withContext(dispatcherProvider.io) {
+            if (forceFetch) {
+                fetchFromRemote()
+            } else {
+                val localFact = factLocalDataSource.getFact()
+                localFact?.let {
+                    Result.success(it.toFactModel())
+                } ?: fetchFromRemote()
+            }
+        }
+    }
+
+    private suspend fun fetchFromRemote(): Result<FactModel> {
+        factNetworkDataSource.getFact().fold({
+            val factEntity = factLocalDataSource.updateFact(factEntity = it.toFactEntity())
+            return Result.success(factEntity.toFactModel())
+        }, {
+            return Result.failure(IOException())
+
+        })
+    }
+}
+
+private fun FactEntity.toFactModel() = FactModel(
+    fact = fact,
+    length = length,
+)
+
+private fun FactResponse.toFactEntity(): FactEntity = FactEntity(
+    fact = fact,
+    length = length,
+)

--- a/app/src/main/java/jp/speakbuddy/edisonandroidexercise/repository/di/RepositoryModule.kt
+++ b/app/src/main/java/jp/speakbuddy/edisonandroidexercise/repository/di/RepositoryModule.kt
@@ -1,0 +1,15 @@
+package jp.speakbuddy.edisonandroidexercise.repository.di
+
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.android.components.ViewModelComponent
+import jp.speakbuddy.edisonandroidexercise.repository.FactRepository
+import jp.speakbuddy.edisonandroidexercise.repository.OfflineFirstFactRepository
+
+@Module
+@InstallIn(ViewModelComponent::class)
+abstract class RepositoryModule {
+    @Binds
+    abstract fun provideFactRepository(offlineFirstFactRepository: OfflineFirstFactRepository): FactRepository
+}

--- a/app/src/main/java/jp/speakbuddy/edisonandroidexercise/repository/model/FactModel.kt
+++ b/app/src/main/java/jp/speakbuddy/edisonandroidexercise/repository/model/FactModel.kt
@@ -1,0 +1,11 @@
+package jp.speakbuddy.edisonandroidexercise.repository.model
+
+/**
+ * Data class that represent FactModel
+ * This class will be the representation of Fact that's fetched either from remote or local
+ */
+data class FactModel(
+    val fact: String,
+    val length: Int,
+)
+

--- a/app/src/main/java/jp/speakbuddy/edisonandroidexercise/ui/fact/FactScreen.kt
+++ b/app/src/main/java/jp/speakbuddy/edisonandroidexercise/ui/fact/FactScreen.kt
@@ -11,9 +11,6 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
@@ -31,13 +28,15 @@ fun FactRoute(
 
     // initialize data
     LaunchedEffect(Unit) {
-        factViewModel.updateFact()
+        factViewModel.updateFact(false)
     }
 
     FactScreen(
         modifier,
         uiState,
-        factViewModel::updateFact
+        {
+            factViewModel.updateFact(true)
+        }
     )
 }
 

--- a/app/src/main/java/jp/speakbuddy/edisonandroidexercise/ui/fact/FactViewModel.kt
+++ b/app/src/main/java/jp/speakbuddy/edisonandroidexercise/ui/fact/FactViewModel.kt
@@ -4,7 +4,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import jp.speakbuddy.edisonandroidexercise.common.DispatcherProvider
-import jp.speakbuddy.edisonandroidexercise.network.datasource.FactNetworkDataSource
+import jp.speakbuddy.edisonandroidexercise.repository.FactRepository
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
@@ -13,15 +13,15 @@ import javax.inject.Inject
 
 @HiltViewModel
 class FactViewModel @Inject constructor(
-    private val factNetworkDataSource: FactNetworkDataSource,
+    private val factRepository: FactRepository,
     private val dispatcherProvider: DispatcherProvider,
 ) : ViewModel() {
     private val _uiState: MutableStateFlow<FactUiState> = MutableStateFlow(FactUiState.INITIAL)
     val uiState = _uiState.asStateFlow()
 
-    fun updateFact() {
+    fun updateFact(forceFetch: Boolean) {
         viewModelScope.launch(dispatcherProvider.main) {
-            factNetworkDataSource.getFact()
+            factRepository.getFact(forceFetch)
                 .onSuccess { factResponse ->
                     _uiState.update {
                         FactUiState.Content(factResponse.fact)

--- a/app/src/test/java/jp/speakbuddy/edisonandroidexercise/local/datasource/FactLocalProtoDataSourceImplTest.kt
+++ b/app/src/test/java/jp/speakbuddy/edisonandroidexercise/local/datasource/FactLocalProtoDataSourceImplTest.kt
@@ -39,9 +39,8 @@ class FactLocalProtoDataSourceImplTest {
     }
 
     @Test
-    fun `when flow return null should return default value`() = runTest {
+    fun `when flow return null should return null`() = runTest {
         // Arrange
-        val expectedFact = FactEntity()
         val mockFlow = mockk<Flow<FactEntity>>()
         coEvery { mockFlow.firstOrNull() } returns null
         coEvery { mockFlow.collect(any()) } just Runs
@@ -51,7 +50,7 @@ class FactLocalProtoDataSourceImplTest {
         val actualFact = factLocalProtoDataSourceImpl.getFact()
 
         // Assert
-        assertEquals(expectedFact, actualFact)
+        assertEquals(null, actualFact)
     }
 
     @Test

--- a/app/src/test/java/jp/speakbuddy/edisonandroidexercise/repository/OfflineFirstFactRepositoryTest.kt
+++ b/app/src/test/java/jp/speakbuddy/edisonandroidexercise/repository/OfflineFirstFactRepositoryTest.kt
@@ -1,0 +1,88 @@
+package jp.speakbuddy.edisonandroidexercise.repository
+
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import jp.speakbuddy.edisonandroidexercise.common.DispatcherProvider
+import jp.speakbuddy.edisonandroidexercise.local.data.FactEntity
+import jp.speakbuddy.edisonandroidexercise.local.datasource.FactLocalDataSource
+import jp.speakbuddy.edisonandroidexercise.network.data.FactResponse
+import jp.speakbuddy.edisonandroidexercise.network.datasource.FactNetworkDataSource
+import jp.speakbuddy.edisonandroidexercise.repository.model.FactModel
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class OfflineFirstFactRepositoryTest {
+
+    private val factNetworkDataSource: FactNetworkDataSource = mockk()
+    private val factLocalDataSource: FactLocalDataSource = mockk()
+    private val dispatcherProvider: DispatcherProvider = mockk {
+        coEvery { io } returns Dispatchers.Unconfined
+    }
+    private val repository = OfflineFirstFactRepository(
+        factNetworkDataSource,
+        factLocalDataSource,
+        dispatcherProvider
+    )
+
+    @Test
+    fun testGetFact_noForceFetch_returnsLocalData() = runTest {
+        // Arrange
+        val localFact = FactEntity("Local fact", 10)
+        coEvery { factLocalDataSource.getFact() } returns localFact
+
+        // Act
+        val result = repository.getFact(forceFetch = false)
+
+        // Assert
+        assertEquals(Result.success(FactModel("Local fact", 10)), result)
+        coVerify(exactly = 0) { factNetworkDataSource.getFact() } // Verify network wasn't called
+    }
+
+    @Test
+    fun testGetFact_forceFetch_fetchesFromRemote() = runTest {
+        // Arrange
+        val remoteFact = FactResponse("Remote fact", 12)
+        coEvery { factNetworkDataSource.getFact() } returns Result.success(remoteFact)
+        coEvery { factLocalDataSource.updateFact(any()) } returns FactEntity("Remote fact", 12)
+
+        // Act
+        val result = repository.getFact(forceFetch = true)
+
+        // Assert
+        assertEquals(Result.success(FactModel("Remote fact", 12)), result)
+        coVerify { factNetworkDataSource.getFact() } // Verify network was called
+    }
+
+    @Test
+    fun testGetFact_noLocalData_fetchesFromRemote() = runTest {
+        // Arrange
+        val remoteFact = FactResponse("Remote fact", 12)
+        coEvery { factLocalDataSource.getFact() } returns null
+        coEvery { factNetworkDataSource.getFact() } returns Result.success(remoteFact)
+        coEvery { factLocalDataSource.updateFact(any()) } returns FactEntity("Remote fact", 12)
+
+        // Act
+        val result = repository.getFact(forceFetch = false)
+
+        // Assert
+        assertEquals(Result.success(FactModel("Remote fact", 12)), result)
+        coVerify { factNetworkDataSource.getFact() } // Verify network was called
+    }
+
+    @Test
+    fun testGetFact_networkError_returnsFailure() = runTest {
+        // Arrange
+        coEvery { factLocalDataSource.getFact() } returns null
+        coEvery { factNetworkDataSource.getFact() } returns Result.failure(Exception("Network error"))
+
+        // Act
+        val result = repository.getFact(forceFetch = false)
+
+        // Assert
+        assert(result.isFailure) // Verify result is a failure
+        coVerify { factNetworkDataSource.getFact() } // Verify network was called
+    }
+}

--- a/app/src/test/java/jp/speakbuddy/edisonandroidexercise/ui/FactViewModelTest.kt
+++ b/app/src/test/java/jp/speakbuddy/edisonandroidexercise/ui/FactViewModelTest.kt
@@ -5,8 +5,8 @@ import io.mockk.clearAllMocks
 import io.mockk.coEvery
 import io.mockk.mockk
 import jp.speakbuddy.edisonandroidexercise.common.DispatcherProvider
-import jp.speakbuddy.edisonandroidexercise.network.data.FactResponse
-import jp.speakbuddy.edisonandroidexercise.network.datasource.FactNetworkDataSource
+import jp.speakbuddy.edisonandroidexercise.repository.FactRepository
+import jp.speakbuddy.edisonandroidexercise.repository.model.FactModel
 import jp.speakbuddy.edisonandroidexercise.ui.common.DefaultTestDispatcherProvider
 import jp.speakbuddy.edisonandroidexercise.ui.fact.FactUiState
 import jp.speakbuddy.edisonandroidexercise.ui.fact.FactViewModel
@@ -17,9 +17,9 @@ import org.junit.Test
 import java.io.IOException
 
 class FactViewModelTest {
-    private val factNetworkDataSource: FactNetworkDataSource = mockk()
+    private val factRepository: FactRepository = mockk()
     private val dispatcherProvider: DispatcherProvider = DefaultTestDispatcherProvider()
-    private val viewModel = FactViewModel(factNetworkDataSource, dispatcherProvider)
+    private val viewModel = FactViewModel(factRepository, dispatcherProvider)
 
     @After
     fun afterEach() {
@@ -29,8 +29,8 @@ class FactViewModelTest {
     @Test
     fun `when updateFact is triggered and fetchNetwork Success, should return ui state with facts correctly`() = runTest {
         val newFact = "New Facts"
-        coEvery { factNetworkDataSource.getFact() } returns Result.success(
-            FactResponse(
+        coEvery { factRepository.getFact(false) } returns Result.success(
+            FactModel(
                 length = newFact.length,
                 fact = newFact
             )
@@ -38,7 +38,7 @@ class FactViewModelTest {
 
         viewModel.uiState.test {
             assertEquals(FactUiState.INITIAL, awaitItem())
-            viewModel.updateFact()
+            viewModel.updateFact(false)
             assertEquals(FactUiState.Content(newFact), awaitItem())
             ensureAllEventsConsumed()
         }
@@ -46,11 +46,11 @@ class FactViewModelTest {
 
     @Test
     fun `when updateFact is triggered and fetchNetwork Failure, should return ui state with facts correctly`() = runTest {
-        coEvery { factNetworkDataSource.getFact() } returns Result.failure(IOException())
+        coEvery { factRepository.getFact(false) } returns Result.failure(IOException())
 
         viewModel.uiState.test {
             assertEquals(FactUiState.INITIAL, awaitItem())
-            viewModel.updateFact()
+            viewModel.updateFact(false)
             assertEquals(FactUiState.Error("Dummy Error Message now"), awaitItem())
             ensureAllEventsConsumed()
         }


### PR DESCRIPTION
Create a repository called FactRepository as abstraction, which will fetch the FactRepository either from network or local
The implementation of FactRepository is OfflineFirstFactRepository, as the name suggest this Repository will load data from offline first, whenever it's empty it will fetch through remote
Sometimes when fetching through remote we encounter issue, and if such cases happen, we simply throw an error, which should be handled by ViewModel later

This PR also updates the ViewModel implementation so that we can trigger fetching either from remote or local (maybe need to create a different function later)

Some improvement that can be made for FactRepository specifically related to local handling is that we can return flow from the LocalDataSource, so that whenever we got an update from the local data, we can automatically provide the update to repository, and then from repository we can also return a flow which can be collected by viewModel, so the flow of data will be a lot cleaner