### PR TITLE
Add FactDisplayDataMapper

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -16,7 +16,7 @@ android {
     defaultConfig {
         applicationId = "jp.speakbuddy.edisonandroidexercise"
         minSdk = 26
-        targetSdk = 34
+        targetSdk = 35
         versionCode = 1
         versionName = "0.0.1"
 

--- a/app/src/main/java/jp/speakbuddy/edisonandroidexercise/dev_plan.md
+++ b/app/src/main/java/jp/speakbuddy/edisonandroidexercise/dev_plan.md
@@ -41,12 +41,12 @@
 - Add FactEntity :white_check_mark:
 - Add FactLocalDataSource :white_check_mark:
 - Add FactNetworkDataSource :white_check_mark:
-- Add FactData :white_check_mark: (renamed to FactModel)
+- Add FactModel :white_check_mark:
 - Add FactRepository :white_check_mark:
 - Update FactViewModel to use FactRepository :white_check_mark:
 - Create FactDisplayMapper
-    - Main Function -> Map FactData to FactDisplay Data
-    - Add Fact Length (value with visibility?)
-    - Add Multiple Cats (value with visibility?)
+    - Main Function -> Map FactModel to FactDisplayData
+    - Add Fact Length
+    - Add Multiple Cats
     - Add Unit Tests
 - Plan about showing image

--- a/app/src/main/java/jp/speakbuddy/edisonandroidexercise/mapper/FactDisplayDataMapper.kt
+++ b/app/src/main/java/jp/speakbuddy/edisonandroidexercise/mapper/FactDisplayDataMapper.kt
@@ -1,0 +1,22 @@
+package jp.speakbuddy.edisonandroidexercise.mapper
+
+import jp.speakbuddy.edisonandroidexercise.repository.model.FactModel
+import jp.speakbuddy.edisonandroidexercise.ui.fact.FactDisplayData
+import javax.inject.Inject
+
+const val FACT_LENGTH_VISIBILITY_THRESHOLD = 100
+const val MULTIPLE_CATS = "cats"
+
+class FactDisplayDataMapper @Inject constructor() {
+    fun map(factModel: FactModel): FactDisplayData {
+        return FactDisplayData(
+            fact = factModel.fact,
+            length = if (factModel.length > FACT_LENGTH_VISIBILITY_THRESHOLD) {
+                "Length > 100"
+            } else {
+                null
+            },
+            showMultipleCats = factModel.fact.contains(MULTIPLE_CATS, ignoreCase = true)
+        )
+    }
+}

--- a/app/src/main/java/jp/speakbuddy/edisonandroidexercise/mapper/FactDisplayDataMapper.kt
+++ b/app/src/main/java/jp/speakbuddy/edisonandroidexercise/mapper/FactDisplayDataMapper.kt
@@ -4,8 +4,8 @@ import jp.speakbuddy.edisonandroidexercise.repository.model.FactModel
 import jp.speakbuddy.edisonandroidexercise.ui.fact.FactDisplayData
 import javax.inject.Inject
 
-const val FACT_LENGTH_VISIBILITY_THRESHOLD = 100
-const val MULTIPLE_CATS = "cats"
+internal const val FACT_LENGTH_VISIBILITY_THRESHOLD = 100
+internal const val MULTIPLE_CATS = "cats"
 
 class FactDisplayDataMapper @Inject constructor() {
     fun map(factModel: FactModel): FactDisplayData {

--- a/app/src/main/java/jp/speakbuddy/edisonandroidexercise/model/FactModel.kt
+++ b/app/src/main/java/jp/speakbuddy/edisonandroidexercise/model/FactModel.kt
@@ -1,6 +1,0 @@
-package jp.speakbuddy.edisonandroidexercise.model
-
-data class FactModel(
-    val fact: String,
-    val length: Int,
-)

--- a/app/src/main/java/jp/speakbuddy/edisonandroidexercise/ui/fact/FactDisplayData.kt
+++ b/app/src/main/java/jp/speakbuddy/edisonandroidexercise/ui/fact/FactDisplayData.kt
@@ -1,0 +1,10 @@
+package jp.speakbuddy.edisonandroidexercise.ui.fact
+
+import androidx.compose.runtime.Stable
+
+@Stable
+data class FactDisplayData(
+    val fact: String,
+    val length: String?,
+    val showMultipleCats: Boolean,
+)

--- a/app/src/main/java/jp/speakbuddy/edisonandroidexercise/ui/fact/FactScreen.kt
+++ b/app/src/main/java/jp/speakbuddy/edisonandroidexercise/ui/fact/FactScreen.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Button
 import androidx.compose.material3.MaterialTheme
@@ -13,6 +14,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -48,11 +50,16 @@ fun FactScreen(
 ) {
     when (uiState) {
         is FactUiState.Content -> {
-            FactContent(factContent = uiState, onRefreshClicked = onRefreshClicked)
+            FactContent(
+                factDisplayData = uiState.factDisplayData,
+                onRefreshClicked = onRefreshClicked
+            )
         }
+
         is FactUiState.Error -> {
             // TODO add Error screen later
         }
+
         FactUiState.Loading -> {
             // TODO add loading mechanism
         }
@@ -62,7 +69,7 @@ fun FactScreen(
 @Composable
 fun FactContent(
     modifier: Modifier = Modifier,
-    factContent: FactUiState.Content,
+    factDisplayData: FactDisplayData,
     onRefreshClicked: () -> Unit,
 ) {
     Column(
@@ -82,9 +89,19 @@ fun FactContent(
         )
 
         Text(
-            text = factContent.fact,
+            text = factDisplayData.fact,
             style = MaterialTheme.typography.bodyLarge
         )
+
+        factDisplayData.length?.let {
+            Text(
+                modifier = Modifier
+                    .fillMaxWidth(),
+                textAlign = TextAlign.End,
+                text = it,
+                style = MaterialTheme.typography.bodySmall
+            )
+        }
 
         Button(onClick = onRefreshClicked) {
             Text(text = "Update fact")
@@ -96,6 +113,12 @@ fun FactContent(
 @Composable
 private fun FactScreenPreview() {
     EdisonAndroidExerciseTheme {
-        FactScreen(uiState = FactUiState.Content("This is sample facts"), onRefreshClicked = { })
+        FactScreen(uiState = FactUiState.Content(
+            FactDisplayData(
+                fact = "This is sample fact",
+                length = "Sample length",
+                showMultipleCats = true,
+            )
+        ), onRefreshClicked = { })
     }
 }

--- a/app/src/main/java/jp/speakbuddy/edisonandroidexercise/ui/fact/FactUiState.kt
+++ b/app/src/main/java/jp/speakbuddy/edisonandroidexercise/ui/fact/FactUiState.kt
@@ -6,7 +6,7 @@ sealed interface FactUiState {
     }
     data object Loading: FactUiState
     data class Content(
-        val fact: String,
+        val factDisplayData: FactDisplayData,
     ) : FactUiState
 
     data class Error(

--- a/app/src/test/java/jp/speakbuddy/edisonandroidexercise/mapper/FactDisplayDataMapperTest.kt
+++ b/app/src/test/java/jp/speakbuddy/edisonandroidexercise/mapper/FactDisplayDataMapperTest.kt
@@ -1,0 +1,58 @@
+package jp.speakbuddy.edisonandroidexercise.mapper
+import jp.speakbuddy.edisonandroidexercise.repository.model.FactModel
+import jp.speakbuddy.edisonandroidexercise.ui.fact.FactDisplayData
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class FactDisplayDataMapperTest {
+
+    private val mapper = FactDisplayDataMapper()
+
+    @Test
+    fun `when map is triggered with fact length less than 100, it should set length to null`() {
+        // Arrange
+        val factModel = FactModel("Short fact", length = FACT_LENGTH_VISIBILITY_THRESHOLD - 1)
+
+        // Act
+        val result = mapper.map(factModel)
+
+        // Assert
+        assertEquals(FactDisplayData("Short fact", null, false), result)
+    }
+
+    @Test
+    fun `when map is triggered with fact length bigger 100, it should set length correctly`() {
+        // Arrange
+        val factModel = FactModel("Long fact", length = FACT_LENGTH_VISIBILITY_THRESHOLD + 1)
+
+        // Act
+        val result = mapper.map(factModel)
+
+        // Assert
+        assertEquals(FactDisplayData("Long fact", "Length > 100", false), result)
+    }
+
+    @Test
+    fun `when map is triggered with multiple cats, it should show multiple cats`() {
+        // Arrange
+        val factModel = FactModel("Fact about $MULTIPLE_CATS", length = 50)
+
+        // Act
+        val result = mapper.map(factModel)
+
+        // Assert
+        assertEquals(FactDisplayData("Fact about $MULTIPLE_CATS", null, true), result)
+    }
+
+    @Test
+    fun `when map is triggered with no multiple cats, it should not show multiple cats`() {
+        // Arrange
+        val factModel = FactModel("Fact about dogs", length = 50)
+
+        // Act
+        val result = mapper.map(factModel)
+
+        // Assert
+        assertEquals(FactDisplayData("Fact about dogs", null, false), result)
+    }
+}


### PR DESCRIPTION
This PR adds FactDisplayDataMapper which has main responsibility of mapping the repository data model (the layer that "combines" network and local data) into UI Friendly data model
Some business logic is added here such as showing the length and also showing the multiple cats

The FactDisplayDataMapper will be triggered after we fetch the repository and will be used as the content of our UI state (which also got changed in this PR)

In this PR I only implement length UI handling, for multiple cats it will be handled in subsequent PR