### PR TITLE
Add Error Handling When Fetching Data From Remote

### DIFF
--- a/app/src/main/java/jp/speakbuddy/edisonandroidexercise/dev_plan.md
+++ b/app/src/main/java/jp/speakbuddy/edisonandroidexercise/dev_plan.md
@@ -1,3 +1,4 @@
+
 # Core Requirements
 ## Persist Latest Cat Fact
 - Goal: Save the latest cat fact locally so it persists between app launches.
@@ -24,8 +25,7 @@
 # Non Core Requirements:
 - Update to toml
 - Update to latest Dependencies
-- Implement Hilt
-- Screenshot tests?
+- CI/CD
 
 
 # Implementation Plan
@@ -50,4 +50,5 @@
     - Add Multiple Cats
     - Add Unit Tests
 - Plan about showing image :white_check_mark:
-- Code Clean Up + Error Handling
+- Error Handling :white_check_mark:
+- Code Cleanup + Docs

--- a/app/src/main/java/jp/speakbuddy/edisonandroidexercise/local/data/FactEntitySerializer.kt
+++ b/app/src/main/java/jp/speakbuddy/edisonandroidexercise/local/data/FactEntitySerializer.kt
@@ -12,7 +12,7 @@ class FactEntitySerializer @Inject constructor(
     private val dispatcherProvider: DispatcherProvider,
 ): Serializer<FactEntity> {
     override val defaultValue: FactEntity
-        get() = FactEntity()
+        get() = FactEntity(length = -1)
 
     override suspend fun readFrom(input: InputStream): FactEntity {
         return try {
@@ -21,7 +21,6 @@ class FactEntitySerializer @Inject constructor(
                 string = input.readBytes().decodeToString()
             )
         } catch (e: Exception) {
-            e.printStackTrace()
             defaultValue
         }
     }

--- a/app/src/main/java/jp/speakbuddy/edisonandroidexercise/local/datasource/FactLocalProtoDataSourceImpl.kt
+++ b/app/src/main/java/jp/speakbuddy/edisonandroidexercise/local/datasource/FactLocalProtoDataSourceImpl.kt
@@ -7,8 +7,14 @@ import javax.inject.Inject
 
 class FactLocalProtoDataSourceImpl @Inject constructor(
     private val factDataStore: DataStore<FactEntity>,
-): FactLocalDataSource {
-    override suspend fun getFact(): FactEntity? = factDataStore.data.firstOrNull()
+) : FactLocalDataSource {
+    override suspend fun getFact(): FactEntity? {
+        val result = factDataStore.data.firstOrNull()
+        if (result == null || result.length == -1) {
+            return null
+        }
+        return result
+    }
 
     override suspend fun updateFact(factEntity: FactEntity): FactEntity {
         return factDataStore.updateData { factEntity }

--- a/app/src/main/java/jp/speakbuddy/edisonandroidexercise/mapper/FactErrorMapper.kt
+++ b/app/src/main/java/jp/speakbuddy/edisonandroidexercise/mapper/FactErrorMapper.kt
@@ -1,0 +1,23 @@
+package jp.speakbuddy.edisonandroidexercise.mapper
+
+import android.content.Context
+import coil3.network.HttpException
+import jp.speakbuddy.edisonandroidexercise.R
+import java.net.UnknownHostException
+import javax.inject.Inject
+
+class FactErrorMapper @Inject constructor(
+    private val context: Context
+) {
+    private val noInternetErrorMessage by lazy { context.getString(R.string.no_internet) }
+    private val serverError by lazy { context.getString(R.string.server_error) }
+    private val unknownError by lazy { context.getString(R.string.unknown_error) }
+
+    fun map(throwable: Throwable): String {
+        return when (throwable) {
+            is UnknownHostException -> noInternetErrorMessage
+            is HttpException -> serverError
+            else -> unknownError
+        }
+    }
+}

--- a/app/src/main/java/jp/speakbuddy/edisonandroidexercise/mapper/di/MapperModule.kt
+++ b/app/src/main/java/jp/speakbuddy/edisonandroidexercise/mapper/di/MapperModule.kt
@@ -7,6 +7,7 @@ import dagger.hilt.InstallIn
 import dagger.hilt.android.components.ViewModelComponent
 import dagger.hilt.android.qualifiers.ApplicationContext
 import jp.speakbuddy.edisonandroidexercise.mapper.FactDisplayDataMapper
+import jp.speakbuddy.edisonandroidexercise.mapper.FactErrorMapper
 
 @Module
 @InstallIn(ViewModelComponent::class)
@@ -14,5 +15,10 @@ object MapperModule {
     @Provides
     fun provideFactDisplayDataMapper(@ApplicationContext context: Context): FactDisplayDataMapper {
         return FactDisplayDataMapper(context)
+    }
+
+    @Provides
+    fun provideErrorMapper(@ApplicationContext context: Context): FactErrorMapper {
+        return FactErrorMapper(context)
     }
 }

--- a/app/src/main/java/jp/speakbuddy/edisonandroidexercise/repository/OfflineFirstFactRepository.kt
+++ b/app/src/main/java/jp/speakbuddy/edisonandroidexercise/repository/OfflineFirstFactRepository.kt
@@ -7,7 +7,6 @@ import jp.speakbuddy.edisonandroidexercise.network.data.FactResponse
 import jp.speakbuddy.edisonandroidexercise.network.datasource.FactNetworkDataSource
 import jp.speakbuddy.edisonandroidexercise.repository.model.FactModel
 import kotlinx.coroutines.withContext
-import java.io.IOException
 import javax.inject.Inject
 
 class OfflineFirstFactRepository @Inject constructor(
@@ -33,8 +32,8 @@ class OfflineFirstFactRepository @Inject constructor(
             val factEntity = factLocalDataSource.updateFact(factEntity = it.toFactEntity())
             return Result.success(factEntity.toFactModel())
         }, {
-            return Result.failure(IOException())
-
+            it.printStackTrace()
+            return Result.failure(it)
         })
     }
 }

--- a/app/src/main/java/jp/speakbuddy/edisonandroidexercise/ui/fact/FactScreen.kt
+++ b/app/src/main/java/jp/speakbuddy/edisonandroidexercise/ui/fact/FactScreen.kt
@@ -1,5 +1,6 @@
 package jp.speakbuddy.edisonandroidexercise.ui.fact
 
+import android.widget.Toast
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -11,6 +12,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.MaterialTheme
@@ -21,6 +23,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -74,7 +77,7 @@ fun FactScreen(
             }
 
             is FactUiState.Error -> {
-                FactError(errorMessage = uiState.errorMessage)
+                FactError(errorMessage = uiState.errorMessage, onRefreshClicked = onRefreshClicked)
             }
 
             // Initial state, doesn't need any implementation
@@ -87,6 +90,7 @@ fun FactScreen(
 fun FactError(
     modifier: Modifier = Modifier,
     errorMessage: String,
+    onRefreshClicked: () -> Unit,
 ) {
     Column(
         modifier.fillMaxSize(),
@@ -105,6 +109,12 @@ fun FactError(
             text = errorMessage,
             style = MaterialTheme.typography.bodyLarge
         )
+
+        Button(onClick = onRefreshClicked) {
+            Text(
+                text = stringResource(R.string.refresh_button)
+            )
+        }
     }
 }
 
@@ -114,6 +124,11 @@ fun FactContent(
     factDisplayData: FactDisplayData,
     onRefreshClicked: () -> Unit,
 ) {
+    factDisplayData.toastMessage?.let {
+        val localContext = LocalContext.current
+        Toast.makeText(localContext, it, Toast.LENGTH_SHORT).show()
+    }
+
     Box(
         modifier = modifier
             .fillMaxSize()

--- a/app/src/main/java/jp/speakbuddy/edisonandroidexercise/ui/fact/FactViewModel.kt
+++ b/app/src/main/java/jp/speakbuddy/edisonandroidexercise/ui/fact/FactViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import jp.speakbuddy.edisonandroidexercise.common.DispatcherProvider
 import jp.speakbuddy.edisonandroidexercise.mapper.FactDisplayDataMapper
+import jp.speakbuddy.edisonandroidexercise.mapper.FactErrorMapper
 import jp.speakbuddy.edisonandroidexercise.repository.FactRepository
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -17,6 +18,7 @@ import javax.inject.Inject
 class FactViewModel @Inject constructor(
     private val factRepository: FactRepository,
     private val factDisplayDataMapper: FactDisplayDataMapper,
+    private val factErrorMapper: FactErrorMapper,
     private val dispatcherProvider: DispatcherProvider,
 ) : ViewModel() {
     private val _uiState: MutableStateFlow<FactUiState> = MutableStateFlow(FactUiState.INITIAL)
@@ -41,9 +43,14 @@ class FactViewModel @Inject constructor(
                     }
                 }
                 .onFailure { throwable ->
-                    // TODO update error message later
+                    val currentUiState = _uiState.value
+                    val message = factErrorMapper.map(throwable)
                     _uiState.update {
-                        FactUiState.Error("Dummy Error Message now")
+                        when (currentUiState) {
+                            is FactUiState.Content -> FactUiState.Content(currentUiState.factDisplayData.copy(toastMessage = message))
+                            is FactUiState.Error -> FactUiState.Error(message)
+                            FactUiState.None -> FactUiState.Error(message)
+                        }
                     }
                 }
         }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -6,4 +6,8 @@
     <string name="multiple_cat_identifier">cats</string>
     <string name="length_sub_description">Length: %d</string>
     <string name="fact_error_title">An Error Occurred</string>
+    <string name="no_internet">No Internet Connection</string>
+    <string name="server_error">Server Error</string>
+    <string name="unknown_error">Unknown Error</string>
+    <string name="refresh_button">Reload</string>
 </resources>

--- a/app/src/test/java/jp/speakbuddy/edisonandroidexercise/local/data/FactEntitySerializerTest.kt
+++ b/app/src/test/java/jp/speakbuddy/edisonandroidexercise/local/data/FactEntitySerializerTest.kt
@@ -24,7 +24,7 @@ class FactEntitySerializerTest {
     }
 
     @Test
-    fun testReadFrom_validInput_returnsFactEntity() = runTest {
+    fun `when serializer read executed with correct data, should return correct data`() = runTest {
         // Arrange
         val input = ByteArrayInputStream("""{"fact":"Test fact", "length": 20}""".toByteArray())
 
@@ -36,7 +36,7 @@ class FactEntitySerializerTest {
     }
 
     @Test
-    fun testReadFrom_invalidInput_returnsDefaultValue() = runTest {
+    fun `when serializer read from invalid data, should return data with length -1`() = runTest {
         // Arrange
         val input = ByteArrayInputStream("invalid json".toByteArray())
 
@@ -44,11 +44,11 @@ class FactEntitySerializerTest {
         val result = serializer.readFrom(input)
 
         // Assert
-        assertEquals(FactEntity(), result)
+        assertEquals(FactEntity(length = -1), result)
     }
 
     @Test
-    fun testWriteTo_writesFactEntityToOutputStream() = runTest {
+    fun `when serializer write function is executed, should set the output stream correctly`() = runTest {
         // Arrange
         val output = ByteArrayOutputStream()
         val factEntity = FactEntity("Test fact", 20)

--- a/app/src/test/java/jp/speakbuddy/edisonandroidexercise/local/datasource/FactLocalProtoDataSourceImplTest.kt
+++ b/app/src/test/java/jp/speakbuddy/edisonandroidexercise/local/datasource/FactLocalProtoDataSourceImplTest.kt
@@ -15,7 +15,7 @@ import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Test
 
-class FactLocalProtoDataLottieSourceImplTest {
+class FactLocalProtoDataSourceImplTest {
 
     private val factDataStore: DataStore<FactEntity> = mockk()
     private val factLocalProtoDataSourceImpl = FactLocalProtoDataSourceImpl(factDataStore)
@@ -45,6 +45,19 @@ class FactLocalProtoDataLottieSourceImplTest {
         coEvery { mockFlow.firstOrNull() } returns null
         coEvery { mockFlow.collect(any()) } just Runs
         coEvery { factDataStore.data } returns mockFlow
+
+        // Act
+        val actualFact = factLocalProtoDataSourceImpl.getFact()
+
+        // Assert
+        assertEquals(null, actualFact)
+    }
+
+    @Test
+    fun `when flow return item with length -1 should return null`() = runTest {
+        // Arrange
+        val expectedFact = FactEntity(length = -1)
+        coEvery { factDataStore.data } returns flowOf(expectedFact)
 
         // Act
         val actualFact = factLocalProtoDataSourceImpl.getFact()

--- a/app/src/test/java/jp/speakbuddy/edisonandroidexercise/mapper/FactErrorMapperTest.kt
+++ b/app/src/test/java/jp/speakbuddy/edisonandroidexercise/mapper/FactErrorMapperTest.kt
@@ -1,0 +1,63 @@
+package jp.speakbuddy.edisonandroidexercise.mapper
+
+import android.content.Context
+import coil3.network.HttpException
+import io.mockk.clearAllMocks
+import io.mockk.every
+import io.mockk.mockk
+import jp.speakbuddy.edisonandroidexercise.R
+import junit.framework.TestCase.assertEquals
+import org.junit.After
+import org.junit.Test
+import java.io.IOException
+import java.net.UnknownHostException
+
+
+class FactErrorMapperTest {
+    private val context: Context = mockk()
+    private val mapper = FactErrorMapper(context)
+    @After
+    fun tearDown() {
+        clearAllMocks()
+    }
+
+    @Test
+    fun `when mapper triggered with error UnknownHostException should return no internet message`() {
+        // Assign
+        every { context.getString(R.string.no_internet) } returns "No Internet"
+        val throwable = mockk<UnknownHostException>()
+
+        // Act
+        val message = mapper.map(throwable)
+
+        // Assert
+        assertEquals("No Internet", message)
+    }
+
+    @Test
+    fun `when mapper triggered with error HttpException should return no internet message`() {
+        // Assign
+        every { context.getString(R.string.server_error) } returns "Server Error"
+        val throwable = mockk<HttpException>()
+
+        // Act
+        val message = mapper.map(throwable)
+
+        // Assert
+        assertEquals("Server Error", message)
+    }
+
+    @Test
+    fun `when mapper triggered with other error should return no internet message`() {
+        // Assign
+        every { context.getString(R.string.unknown_error) } returns "Unknown Error"
+        val throwable = mockk<IOException>()
+
+        // Act
+        val message = mapper.map(throwable)
+
+        // Assert
+        assertEquals("Unknown Error", message)
+    }
+
+}

--- a/app/src/test/java/jp/speakbuddy/edisonandroidexercise/ui/FactViewModelTest.kt
+++ b/app/src/test/java/jp/speakbuddy/edisonandroidexercise/ui/FactViewModelTest.kt
@@ -6,6 +6,7 @@ import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
 import jp.speakbuddy.edisonandroidexercise.mapper.FactDisplayDataMapper
+import jp.speakbuddy.edisonandroidexercise.mapper.FactErrorMapper
 import jp.speakbuddy.edisonandroidexercise.repository.FactRepository
 import jp.speakbuddy.edisonandroidexercise.repository.model.FactModel
 import jp.speakbuddy.edisonandroidexercise.ui.common.DefaultTestDispatcherProvider
@@ -23,8 +24,10 @@ import java.io.IOException
 class FactViewModelTest {
     private val factRepository: FactRepository = mockk()
     private val factDisplayDataMapper: FactDisplayDataMapper = mockk()
+    private val errorMapper: FactErrorMapper = mockk()
     private val dispatcherProvider: DefaultTestDispatcherProvider = DefaultTestDispatcherProvider()
-    private val viewModel = FactViewModel(factRepository, factDisplayDataMapper, dispatcherProvider)
+    private val viewModel =
+        FactViewModel(factRepository, factDisplayDataMapper, errorMapper, dispatcherProvider)
 
     private val expectedImageSource =
         ImageSource.Url("https://png.pngtree.com/png-clipart/20220626/original/pngtree-pink-cute-cat-icon-animal-png-yuri-png-image_8188672.png")


### PR DESCRIPTION
## Description
This PR adds error handling when fetching data from remote, currently there are 2 possibilities of showing error message:
1. When there's no local data -> Currently we show a full screen error message with reload button
2. When there's local data -> We show a toast message

Currently for 2nd functionality it's a bit buggy due to the usage of mutable state which prevent the same data being updated hence prevent the toast for being shown by multiple taps, let me see if I can update the implementation to fix the issue

## Screen Record
Case 1 | Case 2
--- | ---
<video src="https://github.com/user-attachments/assets/502f9195-481f-48d1-9277-8d2cc46f78dd"/> | <video src="https://github.com/user-attachments/assets/206ac03c-5d40-42cf-8db9-69bd15aa0a00"/>


